### PR TITLE
Remove stack trace from logger

### DIFF
--- a/src/FondOfSpryker/Zed/ProductPageSearchExpander/Communication/Plugin/ProductPageSearch/Elasticsearch/ProductPageData/ImageSetDataExpanderPlugin.php
+++ b/src/FondOfSpryker/Zed/ProductPageSearchExpander/Communication/Plugin/ProductPageSearch/Elasticsearch/ProductPageData/ImageSetDataExpanderPlugin.php
@@ -33,8 +33,7 @@ class ImageSetDataExpanderPlugin extends AbstractPlugin implements ProductPageDa
 
         } catch (Exception $exception) {
             $this->getLogger()->warning(
-                sprintf('No images for abstract product with id: %s', $productData['fk_product_abstract']),
-                $exception->getTrace()
+                sprintf('No images for abstract product with id: %s', $productData['fk_product_abstract'])
             );
         }
 


### PR DESCRIPTION
We need to remove the stack trace from the logger, because the trace includes product data as well. 
This can cause a huge amount of data and will flood the logs.